### PR TITLE
Expand package to process GLDAS 2.1 raw data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,9 +61,10 @@ would download GLDAS Noah version 1 in 0.25 degree sampling into the folder
 Supported Products
 ==================
 
-At the moment this package only supports GLDAS Noah data version 1 in grib
-format with a spatial sampling of 0.25 degrees. It should be easy to extend the
-package to support other GLDAS based products. This will be done as need arises.
+At the moment this package supports GLDAS Noah data version 1 in grib
+format and GLDAS Noah data version 2.1 in netCDF format with a spatial sampling of 0.25 degrees. 
+It should be easy to extend the package to support other GLDAS based products. 
+This will be done as need arises.
 
 Documentation
 =============

--- a/gldas/interface.py
+++ b/gldas/interface.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 import warnings
 import numpy as np
@@ -17,7 +17,109 @@ from pynetcf.time_series import GriddedNcOrthoMultiTs
 from datetime import timedelta
 
 from gldas.grid import GLDAS025Cellgrid
+from netCDF4 import Dataset
 
+class GLDAS_Noah_v21_025Img(ImageBase):
+    """
+    Class for reading one GLDAS Noah v2.1 nc file in 0.25° grid.
+
+    Parameters
+    ----------
+    filename: string
+        filename of the GLDAS nc file
+    mode: string, optional
+        mode of opening the file, only 'r' is implemented at the moment
+    parameter : string or list, optional
+        one or list of parameters to read, see GLDAS v2.1 documentation for more information
+        Default : 'SoilMoi0_10cm_inst'
+    array_1D: boolean, optional
+        if set then the data is read into 1D arrays. Needed for some legacy code.
+    """
+    
+    def __init__(self, filename, mode='r', parameter='SoilMoi0_10cm_inst', array_1D=False):
+        super(GLDAS_Noah_v21_025Img, self).__init__(filename, mode=mode)
+
+        if type(parameter) != list:
+            parameter = [parameter]
+        self.parameters = parameter
+        self.fill_values = np.repeat(9999., 1440 * 120)
+        self.grid = GLDAS025Cellgrid()
+        self.array_1D = array_1D
+    
+    def read(self, timestamp=None):
+        
+        #print 'read file: %s' %self.filename
+        #Returns the selected parameters for a gldas image and according metadata
+        return_img = {}
+        return_metadata = {}
+        
+        try:
+            dataset = Dataset(self.filename)
+        except IOError as e:
+            print(e)
+            print(" ".join([self.filename, "can not be opened"]))
+            raise e
+         
+
+        param_names=[]
+        for parameter in self.parameters:
+            param_names.append(parameter)
+            
+        
+        for parameter, variable in dataset.variables.items():
+            if parameter in param_names:
+                param_metadata={}
+                param_data={}           
+                for attrname in variable.ncattrs():
+                    if attrname in ['long_name','units']:
+                        param_metadata.update({str(attrname):getattr(variable,attrname)})
+                        
+                   
+                param_data=dataset.variables[parameter][:]
+                np.ma.set_fill_value(param_data,9999)  
+                
+                param_data=np.concatenate((self.fill_values,
+                                           np.ma.getdata(param_data.filled())
+                                           .flatten()))
+                                        
+                return_img.update({str(parameter):param_data[self.grid.activegpis]})
+                return_metadata.update({str(parameter):param_metadata})
+                        
+            #Check for corrupt files
+                try:
+                    return_img[parameter]
+                except KeyError:
+                    path, thefile = os.path.split(self.filename)
+                    print '%s in %s is corrupt - filling image with NaN values' %(parameter,thefile)
+                    return_img[parameter]  = np.empty(self.grid.n_gpi).fill(np.nan)
+                    return_metadata['corrupt_parameters'].append()
+                    
+	dataset.close()
+        if self.array_1D:
+            return Image(self.grid.activearrlon,
+                         self.grid.activearrlat,
+                         return_img,
+                         return_metadata,
+                         timestamp)
+        else:
+            for key in return_img:
+                return_img[key]=np.flipud(return_img[key].reshape((720,1440)))
+            
+            return Image(np.flipud(self.grid.activearrlon.reshape((720,1440))),
+                         np.flipud(self.grid.activearrlat.reshape((720,1440))),
+                         return_img, 
+                         return_metadata,
+                         timestamp)
+                        
+                
+    def write(self,data):
+        raise NotImplementedError()
+        
+    def flush(self):
+        pass
+    
+    def close(self):
+        pass
 
 class GLDAS_Noah_v1_025Img(ImageBase):
     """
@@ -137,6 +239,71 @@ class GLDAS_Noah_v1_025Img(ImageBase):
     def close(self):
         pass
 
+
+class GLDAS_Noah_v21_025Ds(MultiTemporalImageBase):
+    """
+    Class for reading GLDAS v2.1 images in nc format.
+
+    Parameters
+    ----------
+    data_path : string
+        path to the nc files
+    parameter : string or list, optional
+        one or list of parameters to read, see GLDAS v2.1 documentation for more information
+        Default : 'SoilMoi0_10cm_inst'
+    array_1D: boolean, optional
+        if set then the data is read into 1D arrays. Needed for some legacy code.
+    """
+
+    def __init__(self, data_path, parameter='SoilMoi0_10cm_inst', array_1D=False):
+
+        ioclass_kws = {'parameter': parameter,
+                       'array_1D': array_1D}
+
+        sub_path = ['%Y','%j']
+        filename_templ = "GLDAS_NOAH025_3H.A{datetime}.*.nc4"
+        super(GLDAS_Noah_v21_025Ds, self).__init__(data_path, GLDAS_Noah_v21_025Img,
+                                                  fname_templ=filename_templ,
+                                                  datetime_format="%Y%m%d.%H%M",
+                                                  subpath_templ=sub_path,
+                                                  exact_templ=False,
+                                                  ioclass_kws=ioclass_kws)
+        
+    
+
+    def tstamps_for_daterange(self, start_date, end_date):
+        """
+        return timestamps for daterange,
+
+        Parameters
+        ----------
+        start_date: datetime
+            start of date range
+        end_date: datetime
+            end of date range
+
+        Returns
+        -------
+        timestamps : list
+            list of datetime objects of each available image between
+            start_date and end_date
+        """
+        img_offsets = np.array([timedelta(hours=0),
+                                timedelta(hours=3),
+                                timedelta(hours=6),
+                                timedelta(hours=9),
+                                timedelta(hours=12),
+                                timedelta(hours=15),
+                                timedelta(hours=18),
+                                timedelta(hours=21)])
+
+        timestamps = []
+        diff = end_date - start_date
+        for i in range(diff.days + 1):
+            daily_dates = start_date + timedelta(days=i) + img_offsets
+            timestamps.extend(daily_dates.tolist())
+
+        return timestamps
 
 class GLDAS_Noah_v1_025Ds(MultiTemporalImageBase):
     """

--- a/gldas/interface.py
+++ b/gldas/interface.py
@@ -90,7 +90,7 @@ class GLDAS_Noah_v21_025Img(ImageBase):
                     return_img[parameter]
                 except KeyError:
                     path, thefile = os.path.split(self.filename)
-                    print ('%s in %s is corrupt - filling image with NaN values')%(parameter,thefile)
+                    print ('%s in %s is corrupt - filling image with NaN values' %(parameter,thefile))
                     return_img[parameter]  = np.empty(self.grid.n_gpi).fill(np.nan)
                     return_metadata['corrupt_parameters'].append()
                     

--- a/gldas/interface.py
+++ b/gldas/interface.py
@@ -90,7 +90,7 @@ class GLDAS_Noah_v21_025Img(ImageBase):
                     return_img[parameter]
                 except KeyError:
                     path, thefile = os.path.split(self.filename)
-                    print '%s in %s is corrupt - filling image with NaN values' %(parameter,thefile)
+                    print ('%s in %s is corrupt - filling image with NaN values')%(parameter,thefile)
                     return_img[parameter]  = np.empty(self.grid.n_gpi).fill(np.nan)
                     return_metadata['corrupt_parameters'].append()
                     

--- a/gldas/interface.py
+++ b/gldas/interface.py
@@ -94,7 +94,7 @@ class GLDAS_Noah_v21_025Img(ImageBase):
                     return_img[parameter]  = np.empty(self.grid.n_gpi).fill(np.nan)
                     return_metadata['corrupt_parameters'].append()
                     
-	dataset.close()
+        dataset.close()
         if self.array_1D:
             return Image(self.grid.activearrlon,
                          self.grid.activearrlat,

--- a/gldas/reshuffle.py
+++ b/gldas/reshuffle.py
@@ -45,7 +45,7 @@ def get_filetype(inpath):
     Parameters
     ------------
     input_root: string
-        input path where era interim data was downloaded
+        input path where GLDAS data was downloaded
     '''
     
     onedown=os.path.join(inpath,os.listdir(inpath)[0])

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
-
 from datetime import datetime
 
 from gldas.interface import GLDAS_Noah_v1_025Ds
 from gldas.interface import GLDAS_Noah_v1_025Img
-
+from gldas.interface import GLDAS_Noah_v21_025Ds
+from gldas.interface import GLDAS_Noah_v21_025Img
 
 def test_GLDAS_Noah_v1_025Ds_img_reading():
 
@@ -33,9 +33,59 @@ def test_GLDAS_Noah_v1_025Ds_img_reading():
     assert image.metadata['085_L1']['long_name'] == u'ST Surface temperature of soil K'
 
 
+def test_GLDAS_Noah_v21_025Ds_img_reading():
+
+    parameter = ['SoilMoi10_40cm_inst', 'SoilMoi0_10cm_inst', 'SoilTMP0_10cm_inst',
+                 'AvgSurfT_inst', 'SWE_inst']
+    img = GLDAS_Noah_v21_025Ds(data_path=os.path.join(os.path.dirname(__file__),
+                                                     'test-data',
+                                                     'GLDAS_NOAH_image_data'),
+                              parameter=parameter,
+                              array_1D=True)
+
+    image = img.read(
+        datetime(2015, 1, 1, 0))
+
+    assert sorted(image.data.keys()) == sorted(parameter)
+    assert image.timestamp == datetime(2015, 1, 1, 0)
+    assert round(image.data['SoilMoi0_10cm_inst'][998529],3) == 38.804
+    assert round(image.data['SoilMoi10_40cm_inst'][998529],3) == 131.699
+    assert round(image.data['SoilTMP0_10cm_inst'][998529],3) == 254.506
+    assert round(image.data['AvgSurfT_inst'][998529],3) == 235.553
+    assert round(image.data['SWE_inst'][998529],3) == 108.24
+    assert image.lon.shape == (360 * 180 * (1 / 0.25)**2,)
+    assert image.lon.shape == image.lat.shape
+    assert sorted(list(image.metadata.keys())) == sorted(parameter)
+    assert image.metadata['AvgSurfT_inst']['units'] == u'K'
+    assert image.metadata['AvgSurfT_inst']['long_name'] == u'Average Surface Skin temperature'
+
+
 def test_GLDAS_Noah_v1_025Ds_timestamps_for_daterange():
 
     parameter = ['086_L2', '086_L1', '085_L1', '138', '132', '051']
+    img = GLDAS_Noah_v1_025Ds(data_path=os.path.join(os.path.dirname(__file__),
+                                                     'test-data',
+                                                     'GLDAS_NOAH_image_data'),
+                              parameter=parameter,
+                              array_1D=True)
+
+    tstamps = img.tstamps_for_daterange(datetime(2000, 1, 1),
+                                        datetime(2000, 1, 1))
+    assert len(tstamps) == 8
+    assert tstamps == [datetime(2000, 1, 1, 0),
+                       datetime(2000, 1, 1, 3),
+                       datetime(2000, 1, 1, 6),
+                       datetime(2000, 1, 1, 9),
+                       datetime(2000, 1, 1, 12),
+                       datetime(2000, 1, 1, 15),
+                       datetime(2000, 1, 1, 18),
+                       datetime(2000, 1, 1, 21)]
+
+
+def test_GLDAS_Noah_v21_025Ds_timestamps_for_daterange():
+
+    parameter = ['SoilMoi10_40cm_inst', 'SoilMoi0_10cm_inst', 'SoilTMP0_10cm_inst',
+                 'AvgSurfT_inst', 'SWE_inst']
     img = GLDAS_Noah_v1_025Ds(data_path=os.path.join(os.path.dirname(__file__),
                                                      'test-data',
                                                      'GLDAS_NOAH_image_data'),
@@ -79,6 +129,31 @@ def test_GLDAS_Noah_v1_025Img_img_reading_1D():
     assert image.lon.shape == image.lat.shape
 
 
+def test_GLDAS_Noah_v21_025Img_img_reading_1D():
+
+    parameter = ['SoilMoi10_40cm_inst', 'SoilMoi0_10cm_inst', 'SoilTMP0_10cm_inst',
+                 'AvgSurfT_inst', 'SWE_inst']
+    img = GLDAS_Noah_v21_025Img(os.path.join(os.path.dirname(__file__),
+                                            'test-data',
+                                            'GLDAS_NOAH_image_data',
+                                            '2015',
+                                            '001',
+                                            'GLDAS_NOAH025_3H.A20150101.0000.021.nc4'),
+                               parameter=parameter,
+                               array_1D=True)
+
+    image = img.read()
+
+    assert sorted(image.data.keys()) == sorted(parameter)
+    assert round(image.data['SoilMoi0_10cm_inst'][998529],3) == 38.804
+    assert round(image.data['SoilMoi10_40cm_inst'][998529],3) == 131.699
+    assert round(image.data['SoilTMP0_10cm_inst'][998529],3) == 254.506
+    assert round(image.data['AvgSurfT_inst'][998529],3) == 235.553
+    assert round(image.data['SWE_inst'][998529],3) == 108.24
+    assert image.lon.shape == (360 * 180 * (1 / 0.25)**2,)
+    assert image.lon.shape == image.lat.shape
+
+
 def test_GLDAS_Noah_v1_025Img_img_reading_2D():
 
     parameter = ['086_L2', '086_L1', '085_L1', '138', '132', '051']
@@ -103,5 +178,34 @@ def test_GLDAS_Noah_v1_025Img_img_reading_2D():
     assert image.data['085_L1'][576, 440] == 285.19
     assert image.data['138'][26, 609] == 237.27
     assert image.data['051'][26, 609] == 0
+    assert image.lon.shape == (720, 1440)
+    assert image.lon.shape == image.lat.shape
+
+
+def test_GLDAS_Noah_v21_025Img_img_reading_2D():
+
+    parameter = ['SoilMoi10_40cm_inst', 'SoilMoi0_10cm_inst', 'SoilTMP0_10cm_inst',
+                 'AvgSurfT_inst', 'SWE_inst']
+    img = GLDAS_Noah_v21_025Img(os.path.join(os.path.dirname(__file__),
+                                            'test-data',
+                                            'GLDAS_NOAH_image_data',
+                                            '2015',
+                                            '001',
+                                            'GLDAS_NOAH025_3H.A20150101.0000.021.nc4'),
+                               parameter=parameter)
+
+    image = img.read()
+
+    assert image.data['SoilMoi0_10cm_inst'].shape == (720, 1440)
+    assert image.lon[0, 0] == -179.875
+    assert image.lon[0, 1439] == 179.875
+    assert image.lat[0, 0] == 89.875
+    assert image.lat[719, 0] == -89.875
+    assert sorted(image.data.keys()) == sorted(parameter)
+    assert round(image.data['SoilMoi0_10cm_inst'][26,609],3) == 38.804
+    assert round(image.data['SoilMoi10_40cm_inst'][26,609],3) == 131.699
+    assert round(image.data['SoilTMP0_10cm_inst'][26,609],3) == 254.506
+    assert round(image.data['AvgSurfT_inst'][26,609],3) == 235.553
+    assert round(image.data['SWE_inst'][26,609],3) == 108.24
     assert image.lon.shape == (720, 1440)
     assert image.lon.shape == image.lat.shape


### PR DESCRIPTION
Add classes for detecting and reading GLDAS 2.1 data, change class for reshuffling GLDAS raw data to time series.

- Detect whether input raw data is in grib or netcdf format
- Read input netcdf image data (single file or image stack)
- Reshuffle netcdf image stack to time series format (same as for grib format)