### PR TITLE
Enable compression by default during reshuffling and use 1000 as chunksitze

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.4
+===========
+
+- Add support for GLDAS version 2.1
+- Compress files during reshuffling.
+
 Version 0.3
 ===========
 

--- a/gldas/reshuffle.py
+++ b/gldas/reshuffle.py
@@ -34,38 +34,39 @@ from datetime import datetime
 from pygeogrids import BasicGrid
 
 from repurpose.img2ts import Img2Ts
-from gldas.interface import GLDAS_Noah_v1_025Ds,GLDAS_Noah_v21_025Ds
+from gldas.interface import GLDAS_Noah_v1_025Ds, GLDAS_Noah_v21_025Ds
+
 
 def get_filetype(inpath):
     '''
     Tries to find out the file type by searching for
     grib or nc files two subdirectories into the passed input path.
     If function fails, grib is assumed.
-    
+
     Parameters
     ------------
     input_root: string
         input path where GLDAS data was downloaded
     '''
-    
-    onedown=os.path.join(inpath,os.listdir(inpath)[0])
-    twodown=os.path.join(onedown,os.listdir(onedown)[0])
-            
-    filelist=[]
-    for path, subdirs,files in os.walk(twodown):
+
+    onedown = os.path.join(inpath, os.listdir(inpath)[0])
+    twodown = os.path.join(onedown, os.listdir(onedown)[0])
+
+    filelist = []
+    for path, subdirs, files in os.walk(twodown):
         for name in files:
-            filename,extension=os.path.splitext(name)
+            filename, extension = os.path.splitext(name)
             filelist.append(extension)
-            
+
     if '.nc4' in filelist and '.grb' not in filelist:
         return 'netCDF'
     elif '.grb' in filelist and '.nc4' not in filelist:
         return 'grib'
     else:
-        #if file type cannot be detected, guess grib
+        # if file type cannot be detected, guess grib
         return 'grib'
-        
-        
+
+
 def mkdate(datestring):
     if len(datestring) == 10:
         return datetime.strptime(datestring, '%Y-%m-%d')
@@ -118,6 +119,8 @@ def reshuffle(input_root, outputpath,
                         input_grid=grid,
                         imgbuffer=imgbuffer, cellsize_lat=5.0, cellsize_lon=5.0,
                         global_attr=global_attr,
+                        zlib=True,
+                        unlim_chunksize=1000,
                         ts_attributes=ts_attributes)
     reshuffler.calc()
 


### PR DESCRIPTION
This reduces the filesize of the reshuffled time series by a factor of 2 to 3